### PR TITLE
Allows seeds to be incremental

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,20 +1,5 @@
-puts " === Database seeding starting === "
-
-require 'json'
-data_hash = JSON.load_file("./db/exercises.json")
-puts "Creating exercises"
-
-data_hash.each do |exercise_object|
-    print "."
-    Exercise.create!( 
-        name: exercise_object["name"],
-        body_part: exercise_object["bodyPart"], 
-        equipment: exercise_object["equipment"], 
-        gif_url: exercise_object["gifUrl"], 
-        id: exercise_object["id"],
-        target: exercise_object["target"]
-    )
-end
-
-
-puts " === Database seeding ending === "
+JSON
+  .load_file("./db/exercises.json")
+  .map { _1.transform_keys(&:underscore) }
+  .tap { Exercise.upsert_all(_1) }
+  .then { puts "Loaded exercises: #{_1.size}" }


### PR DESCRIPTION
Depends on https://github.com/unfazedEgnimadevspace/Gracker/pull/20, that should be merged first.

# Why?

When I ran `bin/setup` I got an error due to some exercises that I had loaded earlier in my local database.

# How?

Since the records on the table `exercises` are read-only, meaning that they will not be updated by the application we can always overwrite them when the seeds command run, even in a production environment, without causing any undesired side-effect.

So I changed a bit the mechanics of the seeds file.

Now we are using SQL instruction `UPSERT` instead of `INSERT`. That will try first to `UPDATE` the record if the `ID` is found otherwise, it will create a new record.

By using `upsert_all`, all the records are added with only one SQL instruction which reduces the number of communications between the application and the databases.
As a consequence, it runs instantaneously which makes a progress indicator unnecessary.

# Changed behaviour

## Before

1st run output:
![image](https://github.com/unfazedEgnimadevspace/Gracker/assets/1478616/c0814d20-4cf5-4747-9ea6-abe0c101824e)

2nd run output:
![image](https://github.com/unfazedEgnimadevspace/Gracker/assets/1478616/b3b7cfc1-4f2e-414b-8f9b-df74e01aa781)

## After

1st, 2nd, n-th run will output the same:
![image](https://github.com/unfazedEgnimadevspace/Gracker/assets/1478616/a8c3d7b0-6984-4870-864b-f9f5210691d7)