### PR TITLE
Styled pagination links

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,7 +13,50 @@
  *= require_tree .
  *= require_self
  */
-*{
+* {
     margin: 0;
     padding: 0;
+}
+
+.pagination {
+    display: inline-block;
+    text-align: center;
+    margin-top: 1rem;
+}
+
+.pagination a {
+    color: rgb(55 65 81);
+    float: left;
+    padding: 8px 16px;
+    text-decoration: none;
+    transition: background-color .3s;
+    border: 1px solid #ddd;
+    margin: 0 4px;
+    border: 1px white;
+    border-radius: 5px;
+    background-color: rgb(243 244 246);
+}
+
+
+.pagination em {
+    color: white;
+    float: left;
+    padding: 8px 16px;
+    text-decoration: none;
+    transition: background-color .3s;
+    border: 1px solid #ddd;
+    margin: 0 4px;
+    background-color: rgb(79, 128, 234);
+    border: 1px white;
+    border-radius: 5px;
+}
+
+.pagination span {
+    color: rgb(55 65 81);
+    float: left;
+    padding: 8px 16px;
+    text-decoration: none;
+    transition: background-color .3s;
+    border: 1px solid #ddd;
+    margin: 0 4px;
 }


### PR DESCRIPTION
### Why

Pagination links were looking awful 

### How 

Since the pagination links were coming from the will_paginate gem, i had to inspect the pagination div and find it's class name, then i wrote a couple of css codes present in the application.css file to make the pagination links pleasing to the eye and also matching the ui 

### Changed UI 

How the pagination links look now 
![pagination link](https://github.com/unfazedEgnimadevspace/Gracker/assets/96634477/8d243f78-6122-414d-8a48-2b254b8e9a14)

