### PR TITLE
Fixed the apply_filter minute bug

### DIFF
--- a/app/controllers/app/freestyle_controller.rb
+++ b/app/controllers/app/freestyle_controller.rb
@@ -4,9 +4,13 @@ class App::FreestyleController < App::BaseController
   FILTER_OPTIONS = Exercise.distinct.pluck(:body_part).freeze
 
   # renders all the exercises with that particular body part
+  # also renders all the exercises that match a particular search param
   def index
    apply_filter(params[:filter_by]) 
-   apply_search(params[:search])  
+
+   if params[:search] != nil 
+    apply_search(params[:search])  
+   end
   end
 
   # Renders the filter page where users can choose what body part they want to workout on

--- a/app/controllers/app/freestyle_controller.rb
+++ b/app/controllers/app/freestyle_controller.rb
@@ -8,9 +8,9 @@ class App::FreestyleController < App::BaseController
   def index
    apply_filter(params[:filter_by]) 
 
-   if params[:search] != nil 
-    apply_search(params[:search])  
-   end
+    if params[:search] != nil 
+      @freestyle_exercises = Exercise.search(params[:search]).paginate(page: params[:page], per_page: 12) 
+    end
   end
 
   # Renders the filter page where users can choose what body part they want to workout on
@@ -27,9 +27,6 @@ class App::FreestyleController < App::BaseController
     when *FILTER_OPTIONS
       @freestyle_exercises = Exercise.where(body_part: filter_option).paginate(page: params[:page], per_page: 12)
     end
-  end
-  def apply_search(search_option)
-    @freestyle_exercises = Exercise.where("name LIKE ?", "%#{search_option}%").paginate(page: params[:page], per_page: 12)
   end
   
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,4 +1,11 @@
 class Exercise < ApplicationRecord
     #This is a read only class and the objects created from this class are created from the rails db:seed command ran in the bin/setup. The data served by this class is static 
     has_many :trainings
+
+    class << self 
+        def search(search_params)
+          self.where("name LIKE ?", "%#{search_params}%")
+        end
+        
+    end
 end


### PR DESCRIPTION
### Why 

When a user tries to filter the exercises by body parts only, the index action runs the apply_search method after the apply_filter method with a empty parameter returning all the exercises in the database. 

### How 

I checked if the search params is empty before running the apply_search method 