### PR TITLE
Fix for the devise redirect to the wrong root path 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
     protected 
   
     def configure_permitted_parameters
-        devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :email, :password, :password_confirmation])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :email, :password, :password_confirmation])
     end
+    def after_sign_in_path_for(resource)
+      app_root_url
+    end
+    
 end


### PR DESCRIPTION
### Why 

Devise was redirecting to website module root instead of the app module root after users successfully sign in, this pull request solves issue #46 

### How

I created a method called _after_sign_in_path_for_ that returns the right url for devise to redirect to. This method is in the _application_controller_

