### PR TITLE
Created a one to many relationship between user and planned workouts

### DIFF
--- a/app/models/planned_workout.rb
+++ b/app/models/planned_workout.rb
@@ -5,4 +5,5 @@ class PlannedWorkout < ApplicationRecord
     validates :description, length: {maximum: 130, allow_nil: true}
     validates :hours, numericality: {greater_than_or_equal_to: 0, less_than_or_equal_to: 12 }
     validates :minutes, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 59 }
+    belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
-  has_many :foods      
-  has_many :trainings 
+  has_many :foods, dependent: :destroy      
+  has_many :trainings, dependent: :destroy
+  has_many :planned_workouts, dependent: :destroy 
 end


### PR DESCRIPTION
### Why

We want users to be able to create multiple planned workouts with only one account. And to achieve that we need to implement a one to many relationship between the _user_ and _planned_workouts_ models. 

### How 

While writing the code for pull request #59 I created a user_id column on the planned_workouts model solely for the implementation of this one to many relationship.

In this pull request the one to many relationship was implemented by adding  _has_many :plannned_workouts_  to the user model and adding _belongs_to :user_  in the planned_workouts model.

I also made all the relationships created to be dependent on the user being destroyed.
