### PR TITLE
UI pages for planned workouts

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -60,3 +60,49 @@
     border: 1px solid #ddd;
     margin: 0 4px;
 }
+#planned_workout_minutes{
+    appearance: none;
+    display: block;
+    width: 100%;
+    background-color: rgb(229 231 235);
+    color: rgb(55 65 81);
+    border: 1px;
+    border-color: rgb(229 231 235);
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.25;
+    border-radius: 0.25rem;
+}
+#plannned_workout_minutes:focus{
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    background-color: #ffffff;
+    border-color: rgb(249 250 251);
+    border-radius: 0.25rem;
+}
+#planned_workout_hours{
+    appearance: none;
+    display: block;
+    width: 100%;
+    background-color: rgb(229 231 235);
+    color: rgb(55 65 81);
+    border: 1px;
+    border-color: rgb(229 231 235);
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.25;
+    border-radius: 0.25rem;
+}
+#plannned_workout_hours:focus{
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    background-color: #ffffff;
+    border-color: rgb(249 250 251);
+    border-radius: 0.25rem;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -106,3 +106,49 @@
     border-color: rgb(249 250 251);
     border-radius: 0.25rem;
 }
+#planned_workout_sets{
+    appearance: none;
+    display: block;
+    width: 100%;
+    background-color: rgb(229 231 235);
+    color: rgb(55 65 81);
+    border: 1px;
+    border-color: rgb(229 231 235);
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.25;
+    border-radius: 0.25rem;
+}
+#planned_workout_reps{
+    appearance: none;
+    display: block;
+    width: 100%;
+    background-color: rgb(229 231 235);
+    color: rgb(55 65 81);
+    border: 1px;
+    border-color: rgb(229 231 235);
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.25;
+    border-radius: 0.25rem;
+}
+#plannned_workout_reps:focus{
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    background-color: #ffffff;
+    border-color: rgb(249 250 251);
+    border-radius: 0.25rem;
+}
+#plannned_workout_sets:focus{
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    background-color: #ffffff;
+    border-color: rgb(249 250 251);
+    border-radius: 0.25rem;
+}

--- a/app/controllers/app/planned_workouts_controller.rb
+++ b/app/controllers/app/planned_workouts_controller.rb
@@ -1,6 +1,7 @@
 class App::PlannedWorkoutsController < App::BaseController
   before_action :check_current_user
   before_action :set_planned_workout, only: [:edit, :update, :show, :destroy]
+  before_action :get_exercise_object, only: [:edit, :update, :show, :destroy]
 
   def index
     @planned_workouts = current_user.planned_workouts.paginate(page: params[:page], per_page: 10)
@@ -26,6 +27,7 @@ class App::PlannedWorkoutsController < App::BaseController
   
 
   def edit
+    
   end  
 
   def update
@@ -62,11 +64,15 @@ class App::PlannedWorkoutsController < App::BaseController
   private 
 
   def planned_workouts_params
-    params.require(:planned_workout).permit(:date, :completed, :user_id, :exercise_id, :description, :hours, :minutes)
+    params.require(:planned_workout).permit(:date, :completed, :user_id, :exercise_id, :description, :hours, :minutes, :sets, :reps)
   end
 
   def set_planned_workout
     @planned_workout = current_user.planned_workouts.find(params[:id])
+  end
+
+  def get_exercise_object
+    @exercise_object = Exercise.find(@planned_workout.exercise_id)
   end
   
 end

--- a/app/controllers/app/planned_workouts_controller.rb
+++ b/app/controllers/app/planned_workouts_controller.rb
@@ -10,6 +10,7 @@ class App::PlannedWorkoutsController < App::BaseController
   end
   
   def new
+    @choosen_exercise = Exercise.find(params[:exercise])
     @planned_workout = current_user.planned_workouts.build
   end
 

--- a/app/models/planned_workout.rb
+++ b/app/models/planned_workout.rb
@@ -6,6 +6,8 @@ class PlannedWorkout < ApplicationRecord
     validates :description, length: {maximum: 130, allow_nil: true}
     validates :hours, numericality: {greater_than_or_equal_to: 0, less_than_or_equal_to: 12 }
     validates :minutes, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 59 }
+    validates :sets, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 10}
+    validates :reps, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 100}
     belongs_to :user
 
     private

--- a/app/models/planned_workout.rb
+++ b/app/models/planned_workout.rb
@@ -1,4 +1,5 @@
 class PlannedWorkout < ApplicationRecord
+    before_save :calculate_duration_in_minutes
     validates :date, presence: true
     validates :completed, inclusion: {in: [true, false]}
     validates :duration, numericality: {greater_than: 0, allow_nil: true}
@@ -6,4 +7,10 @@ class PlannedWorkout < ApplicationRecord
     validates :hours, numericality: {greater_than_or_equal_to: 0, less_than_or_equal_to: 12 }
     validates :minutes, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 59 }
     belongs_to :user
+
+    private
+
+    def calculate_duration_in_minutes
+        self.duration = (self.hours.to_i * 60) + self.minutes
+    end
 end

--- a/app/views/app/planned_workouts/edit.html.erb
+++ b/app/views/app/planned_workouts/edit.html.erb
@@ -1,4 +1,43 @@
-<div>
-  <h1 class="font-bold text-4xl">PlannedWorkouts#edit</h1>
-  <p>Find me in app/views/planned_workouts/edit.html.erb</p>
-</div>
+<section class="flex flex-col items-center gap-4 bg-white   md:flex-row mx-3 "> 
+   <%= image_tag(exercise_gif_url(@exercise_object) , class: "object-cover w-full rounded-t-lg md:h-full md:w-full md:rounded-none md:rounded-l-lg")%> 
+    <%= form_with(model: @planned_workout, url:  app_planned_workout_url(@planned_workout), local: true, class: "w-full max-w-[28rem] md:max-w-lg mx-12", data: {turbo: false}) do |f|%>
+      <div class="flex flex-wrap -mx-3 mb-6">
+        <div class="w-full px-3">
+          <%= f.label :exercise_name, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
+          <%= f.text_field :exercise_name, readonly: true, value: @exercise_object.name, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
+        </div>
+      </div>
+       <div class="flex flex-wrap -mx-3 mb-6">
+        <div class="w-full px-3">
+          <%= f.label :date, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
+          <%= f.date_field :date, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
+        </div>
+      </div>
+      <div class="flex w-full justify-between align-center gap-3">
+          <div class="w-full">
+            <%= f.label :hours, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :hours, (0..12).to_a%>
+          </div>
+          <div class="w-full">
+            <%= f.label :minutes, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :minutes,(0..59).to_a%>
+          </div>
+      </div>
+      <div class="flex w-full justify-between align-center gap-3">
+          <div class="w-full">
+            <%= f.label :sets, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :sets, (0..10).to_a%>
+          </div>
+          <div class="w-full">
+            <%= f.label :reps, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :reps,(0..100).to_a%>
+          </div>
+      </div>
+      <div>
+          <%= f.label :description, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+          <%= f.text_area :description, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500 h-36"%>
+      </div>   
+      <%= f.hidden_field :exercise_id, value: @exercise_object.id %>
+      <%= submit_tag 'Update', class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2 mt-12 " %>
+    <% end %>
+</section>

--- a/app/views/app/planned_workouts/index.html.erb
+++ b/app/views/app/planned_workouts/index.html.erb
@@ -1,4 +1,54 @@
-<div>
-  <h1 class="font-bold text-4xl">PlannedWorkouts#index</h1>
-  <p>Find me in app/views/planned_workouts/index.html.erb</p>
-</div>
+<% provide(:title, "Planned Workouts") %>
+  <% if @planned_workouts.empty? %>
+    <%= render 'no_records'%>
+  <% else %>  
+    <section class="mx-6 md:mx-8 lg:mx-12 pt-3 mb-7">
+      <%= will_paginate @planned_workouts  %>
+      <div class="flex align-center justify-between mt-5">
+        <h3 class="text-2xl font-medium text-center text-indigo-400 mb-8 md:mt-4">Planned Workouts</h3>
+        <%= link_to  "New", app_planworkouts_path, class: "text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-3 py-2 mr-2 mb-2 h-[50%]"%>
+      </div>
+      <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-10">
+        <% @planned_workouts.each do |planned_workout|%>
+          <li class="max-w-sm bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700 px-3 py-3">  
+              <div class="rounded-xl">
+                <div class="flex flex-col p-4 rounded-xl bg-white">
+                    <div class="flex align-center justify-between mt-2 p-1">
+                      <span class="font-light text-medium">Exercise: </span>
+                      <span class="font-light text-sm"><%= Exercise.find(planned_workout.exercise_id).name.truncate(25) %></span>
+                    </div>
+                    <div class="flex align-center justify-between mt-2 p-1">
+                      <span class="font-light text-sm">Date:</span>
+                      <span class="font-light text-sm"><%= planned_workout.date %></span>
+                    </div>
+                    <div class="flex align-center justify-between mt-2 p-1">
+                      <span class="font-light text-base">Completed:</span>
+                      <span class="font-light text-sm"><%= planned_workout.completed %></span>
+                    </div>
+                    <div class="flex align-center justify-between mt-2 p-1">
+                      <span class="font-light text-base">Duration:</span>
+                      <span class="font-light text-sm"><%= planned_workout.duration %></span>
+                    </div>
+                    <div class="flex align-center justify-between mt-2 p-1">
+                      <span class="font-light text-base">Sets:</span>
+                      <span class="font-light text-sm"><%= planned_workout.sets %></span>
+                    </div>
+                    <div class="flex align-center justify-between mt-2 p-1">
+                      <span class="font-light text-base">Reps:</span>
+                      <span class="font-light text-sm"><%= planned_workout.reps %></span>
+                    </div>
+                      <div class="flex flex-col align-center justify-between mt-2 p-1 mx-auto">
+                        <u class="font-light text-base text-center mb-4">Description</u>
+                        <p class="text-center font-light text-base "><%= planned_workout.description %></p>
+                      </div>
+                    <div class="flex justify-between align-center mt-7">
+                      <%= link_to  "Show", app_planned_workout_path(planned_workout), class: "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 font-medium rounded-lg text-sm px-4 py-2 mr-2 mb-2" %>
+                      <%= link_to  "Delete", app_planned_workout_path(planned_workout), data:{"turbo_method": :delete, turbo_confirm: "Are you sure"}, class: "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-red-800 focus:ring-4 hover:text-white font-medium rounded-lg text-sm px-4 py-2 mr-2 mb-2 duration-100" %>
+                    </div>
+                </div>
+              </div> 
+          </li>  
+        <% end %>
+      </ul>
+    </section> 
+  <% end %>  

--- a/app/views/app/planned_workouts/new.html.erb
+++ b/app/views/app/planned_workouts/new.html.erb
@@ -1,0 +1,29 @@
+<section class="flex flex-col items-center gap-4 bg-white   md:flex-row mx-3 "> 
+    <%# <%= image_tag(exercise_gif_url(@freestyle_exercise) , class: "object-cover w-full rounded-t-lg md:h-full md:w-full md:rounded-none md:rounded-l-lg")%> %>
+    <%= form_with(model: @planned_workout, url:  app_planned_workouts_url, local: true, class: "w-full max-w-[28rem] md:max-w-lg mx-12", data: {turbo: false}) do |f|%>
+      <div class="flex flex-wrap -mx-3 mb-6">
+        <div class="w-full px-3">
+          <%= f.label :exercise_name, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
+          <%= f.text_field :exercise_name, readonly: true, value: @freestyle_exercise.name, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
+        </div>
+      </div>
+      <%= f.hidden_field :exercise_id, value: @freestyle_exercise.id %>
+      <div class="flex flex-wrap -mx-3 mb-6">
+        <div class="w-full px-3">
+          <%= f.label :weight, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
+          <%= f.number_field :weight, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
+        </div>
+      </div>
+      <div class="flex flex-wrap -mx-3 mb-6">
+        <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
+          <%= f.label :number_of_sets, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" %>
+          <%= f.number_field :number_of_sets, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500", min: 1, max: 10 %>
+        </div>
+        <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
+          <%= f.label :number_of_reps, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
+          <%= f.number_field :number_of_reps,class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500", min: 1, max: 100 %>
+        </div>
+      </div>
+      <%= submit_tag 'Record', class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2 mt-12 " %>
+    <% end %>
+</section>

--- a/app/views/app/planned_workouts/new.html.erb
+++ b/app/views/app/planned_workouts/new.html.erb
@@ -1,29 +1,33 @@
 <section class="flex flex-col items-center gap-4 bg-white   md:flex-row mx-3 "> 
-    <%# <%= image_tag(exercise_gif_url(@freestyle_exercise) , class: "object-cover w-full rounded-t-lg md:h-full md:w-full md:rounded-none md:rounded-l-lg")%> %>
+   <%= image_tag(exercise_gif_url(@choosen_exercise) , class: "object-cover w-full rounded-t-lg md:h-full md:w-full md:rounded-none md:rounded-l-lg")%> 
     <%= form_with(model: @planned_workout, url:  app_planned_workouts_url, local: true, class: "w-full max-w-[28rem] md:max-w-lg mx-12", data: {turbo: false}) do |f|%>
       <div class="flex flex-wrap -mx-3 mb-6">
         <div class="w-full px-3">
           <%= f.label :exercise_name, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
-          <%= f.text_field :exercise_name, readonly: true, value: @freestyle_exercise.name, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
+          <%= f.text_field :exercise_name, readonly: true, value: @choosen_exercise.name, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
         </div>
       </div>
-      <%= f.hidden_field :exercise_id, value: @freestyle_exercise.id %>
-      <div class="flex flex-wrap -mx-3 mb-6">
+       <div class="flex flex-wrap -mx-3 mb-6">
         <div class="w-full px-3">
-          <%= f.label :weight, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
-          <%= f.number_field :weight, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
+          <%= f.label :date, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
+          <%= f.date_field :date, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"%>
         </div>
       </div>
-      <div class="flex flex-wrap -mx-3 mb-6">
-        <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
-          <%= f.label :number_of_sets, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" %>
-          <%= f.number_field :number_of_sets, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500", min: 1, max: 10 %>
-        </div>
-        <div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
-          <%= f.label :number_of_reps, class: "block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"%>
-          <%= f.number_field :number_of_reps,class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500", min: 1, max: 100 %>
-        </div>
+      <div class="flex w-full justify-between align-center gap-3">
+          <div class="w-full">
+            <%= f.label :hours, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :hours, (0..12).to_a%>
+          </div>
+          <div class="w-full">
+            <%= f.label :minutes, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :minutes,(0..59).to_a%>
+          </div>
       </div>
-      <%= submit_tag 'Record', class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2 mt-12 " %>
+      <div>
+          <%= f.label :description, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+          <%= f.text_area :description, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500 h-36"%>
+      </div>   
+      <%= f.hidden_field :exercise_id, value: @choosen_exercise.id %>
+      <%= submit_tag 'Confirm', class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2 mt-12 " %>
     <% end %>
 </section>

--- a/app/views/app/planned_workouts/new.html.erb
+++ b/app/views/app/planned_workouts/new.html.erb
@@ -23,11 +23,21 @@
             <%= f.select :minutes,(0..59).to_a%>
           </div>
       </div>
+      <div class="flex w-full justify-between align-center gap-3">
+          <div class="w-full">
+            <%= f.label :sets, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :sets, (0..10).to_a%>
+          </div>
+          <div class="w-full">
+            <%= f.label :reps, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
+            <%= f.select :reps,(0..100).to_a%>
+          </div>
+      </div>
       <div>
           <%= f.label :description, class: 'block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2'%>
           <%= f.text_area :description, class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500 h-36"%>
       </div>   
       <%= f.hidden_field :exercise_id, value: @choosen_exercise.id %>
-      <%= submit_tag 'Confirm', class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2 mt-12 " %>
+      <%= submit_tag 'Plan', class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2 mt-12 " %>
     <% end %>
 </section>

--- a/app/views/app/planned_workouts/show.html.erb
+++ b/app/views/app/planned_workouts/show.html.erb
@@ -1,4 +1,43 @@
-<div>
-  <h1 class="font-bold text-4xl">PlannedWorkouts#show</h1>
-  <p>Find me in app/views/planned_workouts/show.html.erb</p>
-</div>
+<section class="mx-6 md:mx-8 lg:mx-12 pt-3 mb-20 mt-4 mb-7">
+  <h3 class="text-2xl font-medium text-center text-indigo-400 mb-8 mt-4"> Planned workout <%= @planned_workout.id%></h3>
+ <div class="max-w-lg bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700 px-3 py-3 mx-auto">  
+    <div class="rounded-xl">
+      <div class="flex flex-col p-4 rounded-xl bg-white">
+          <div class="flex align-center justify-between mt-2 p-1">
+            <span class="font-light text-medium">Exercise: </span>
+            <span class="font-light text-sm"><%= @exercise_object.name.capitalize %></span>
+          </div>
+          <div class="flex align-center justify-between mt-2 p-1">
+            <span class="font-light text-sm">Date</span>
+            <span class="font-light text-sm"><%= @planned_workout.date %></span>
+          </div>
+          <div class="flex align-center justify-between mt-2 p-1">
+            <span class="font-light text-sm">Completed</span>
+            <span class="font-light text-sm capitalize"><%= @planned_workout.completed %></span>
+          </div>
+          <div class="flex align-center justify-between mt-2 p-1">
+            <span class="font-light text-base">Duration:</span>
+            <span class="font-light text-sm"><%= @planned_workout.duration %> minutes</span>
+          </div>
+          <div class="flex align-center justify-between mt-2 p-1">
+            <span class="font-light text-base">Sets:</span>
+            <span class="font-light text-sm"><%= @planned_workout.sets %></span>
+          </div>
+          <div class="flex align-center justify-between mt-2 p-1">
+            <span class="font-light text-base">Reps:</span>
+            <span class="font-light text-sm"><%= @planned_workout.reps %></span>
+          </div>
+          <div class="flex flex-col align-center justify-between mt-2 p-1 mx-auto">
+            <u class="font-light text-base text-center mb-4">Description</u>
+            <p class="text-center font-light text-base "><%=@planned_workout.description %></p>
+          </div>
+          
+          <div class="flex justify-between align-center mt-12">
+            <%= link_to "Back", app_planned_workouts_url, class: "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 font-medium rounded-lg text-sm px-4 py-2 mr-2 mb-2"%>
+            <%= link_to  "Update", edit_app_planned_workout_path(@planned_workout), class: "text-gray-900 bg-white border border-gray-300 hover:border-blue-300 focus:outline-none hover:bg-blue-800 hover:text-white focus:ring-4 focus:ring-gray-200 font-medium rounded-lg text-sm px-4 py-2 mr-2 mb-2 duration-100" %>
+            <%= link_to  "Delete", app_planned_workout_path(@planned_workout), data:{"turbo_method": :delete, turbo_confirm: "Are you sure"}, class: "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-red-800 focus:ring-4 hover:text-white font-medium rounded-lg text-sm px-4 py-2 mr-2 mb-2 duration-100" %>
+          </div>
+      </div>
+    </div> 
+  </div>
+</section>

--- a/app/views/app/training/new.html.erb
+++ b/app/views/app/training/new.html.erb
@@ -1,4 +1,3 @@
-
 <section class="flex flex-col items-center gap-4 bg-white   md:flex-row mx-3 "> 
     <%= image_tag(exercise_gif_url(@freestyle_exercise) , class: "object-cover w-full rounded-t-lg md:h-full md:w-full md:rounded-none md:rounded-l-lg")%>
     <%= form_with(model: @training, url:  app_training_index_url, local: true, class: "w-full max-w-[28rem] md:max-w-lg mx-12", data: {turbo: false}) do |f|%>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -27,7 +27,7 @@
                 <%= link_to  "Track your meals", app_foods_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white"%>
               </li>
               <li>
-                <%= link_to  "Plan your Workouts", app_planworkouts_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white"%>
+                <%= link_to  "Plan your Workouts", app_planned_workouts_url, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white"%>
               </li>
               <hr>
               <li>

--- a/db/migrate/20230920134508_add_sets_and_reps_to_planned_workouts.rb
+++ b/db/migrate/20230920134508_add_sets_and_reps_to_planned_workouts.rb
@@ -1,0 +1,6 @@
+class AddSetsAndRepsToPlannedWorkouts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planned_workouts, :sets, :integer
+    add_column :planned_workouts, :reps, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_201042) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_20_134508) do
   create_table "contacts", force: :cascade do |t|
     t.string "email"
     t.string "subject"
@@ -53,6 +53,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_201042) do
     t.integer "duration"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sets"
+    t.integer "reps"
   end
 
   create_table "trainings", force: :cascade do |t|


### PR DESCRIPTION
### Why 
We needed a ui page for users to be able to create a planned workout from the exercise chosen. 

### How 
I created a form on  the _new_ html page under planned workouts view , that includes columns like exercise name description and so on. This columns are what are on the planned workout model.

This how the previous image of the new html page looked like

![new previous planned workouts](https://github.com/unfazedEgnimadevspace/Gracker/assets/96634477/0e0a0cc5-81ea-410f-aaa6-92d59b730807)

This is how it looks now
![new now planned workouts mobile](https://github.com/unfazedEgnimadevspace/Gracker/assets/96634477/93c433fc-ab3a-4056-9e47-c3e97a9a19bd)
![new now planned workouts](https://github.com/unfazedEgnimadevspace/Gracker/assets/96634477/75894892-3cd1-48e3-b2c5-6303b46c2fbf)


I also created a calculate_duration_in_minutes  private function  that converts the hours and minutes columns to just minutes for a better user experience as well